### PR TITLE
Event handlers

### DIFF
--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -21,7 +21,6 @@ function exec(fn, args, e, node, vm) {
 
 	if (out1 === false || out2 === false || out3 === false) {
 		e.preventDefault();
-		e.stopPropagation();
 		return false;
 	}
 }

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -3,21 +3,6 @@ import { getVm } from './utils';
 import { onevent } from './config';
 import { devNotify } from "./addons/devmode";
 
-const registry = {};
-
-function listen(ontype) {
-	if (registry[ontype]) return;
-	registry[ontype] = true;
-	bind(doc, ontype, handle, true);
-}
-
-/*
-function unlisten(ontype) {
-	if (registry[ontype])
-		doc.removeEventListener(ontype.slice(2), handle, USE_CAPTURE);
-}
-*/
-
 function unbind(el, type, fn, capt) {
 	el.removeEventListener(type.slice(2), fn, capt);
 }
@@ -49,6 +34,7 @@ function ancestEvDefs(type, node) {
 			if ((evDef = attrs[ontype]) && isArr(evDef))
 				evDefs.push(evDef);
 		}
+        if(node.vm == null) { break; }                                                                                  // stop at vm
 		node = node.parent;
 	}
 
@@ -94,8 +80,14 @@ export function patchEvent(node, name, nval, oval) {
 
 	if (isFunc(nval))
 		bind(el, name, nval, false);
-	else if (nval != null)
-		listen(name);
+	else if (nval != null) {
+		let vmel = getVm(node).node.el;
+        if (!vmel._flag) { vmel._flag = {}; }
+    	if (!vmel._flag[name]) {
+        	vmel._flag[name] = true;
+        	bind(vmel, name, handle, false);
+        }
+    }
 
 	if (isFunc(oval))
 		unbind(el, name, oval, false);

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -13,7 +13,7 @@ function bind(el, type, fn, capt) {
 
 function exec(fn, args, evt, evtnod, hdlnod) {
     var vm   = getVm(hdlnod);
-	var out1 = fn.apply(vm, args.concat([evt, evtnod, vm, vm.data])), out2, out3;
+	var out1 = fn.apply(hdlnod.el, args.concat([evt, evtnod, vm, vm.data])), out2, out3;
 
 	if (FEAT_ONEVENT) {
 		out2 = vm.onevent(evt, evtnod, vm, vm.data, args),

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -11,16 +11,17 @@ function bind(el, type, fn, capt) {
 	el.addEventListener(type.slice(2), fn, capt);
 }
 
-function exec(fn, args, e, node, vm) {
-	var out1 = fn.apply(vm, args.concat([e, node, vm, vm.data])), out2, out3;
+function exec(fn, args, evt, evtnod, hdlnod) {
+    var vm   = getVm(hdlnod);
+	var out1 = fn.apply(vm, args.concat([evt, evtnod, vm, vm.data])), out2, out3;
 
 	if (FEAT_ONEVENT) {
-		out2 = vm.onevent(e, node, vm, vm.data, args),
-		out3 = onevent.call(null, e, node, vm, vm.data, args);
+		out2 = vm.onevent(evt, evtnod, vm, vm.data, args),
+		out3 = onevent.call(null, evt, evtnod, vm, vm.data, args);
 	}
 
 	if (out1 === false || out2 === false || out3 === false) {
-		e.preventDefault();
+		evt.preventDefault();
 		return false;
 	}
 }
@@ -31,7 +32,7 @@ function ancestEvDefs(type, node) {
 	while (node) {
 		if (attrs = node.attrs) {
 			if ((evDef = attrs[ontype]) && isArr(evDef))
-				evDefs.push(evDef);
+				evDefs.push({ def: evDef, node: node });
 		}
         if(node.vm == null) { break; }                                                                                  // stop at vm
 		node = node.parent;
@@ -48,10 +49,9 @@ function handle(e) {
 
 	var evDefs = ancestEvDefs(e.type, node);
 
-	var vm = getVm(node);
-
 	for (var i = 0; i < evDefs.length; i++) {
-		var res = exec(evDefs[i][0], evDefs[i].slice(1), e, node, vm);
+        var evd = evDefs[i];
+		var res = exec(evd.def[0], evd.def.slice(1), e, node, evd.node);
 
 		if (res === false)
 			break;

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -47,7 +47,7 @@ function ancestEvDefs(type, node) {
 	while (node) {
 		if (attrs = node.attrs) {
 			if ((evDef = attrs[ontype]) && isArr(evDef))
-				evDefs.unshift(evDef);
+				evDefs.push(evDef);
 		}
 		node = node.parent;
 	}


### PR DESCRIPTION
Changes to sequence of parameterized event handler invocation:

  1. Invoke handlers from innermost to outermost, matching what the normal bubbling would be.
  2. Allow events to continue to propagate after handler returns false and handling at that level stops.
  3. Attach listener to the nearest VM's element to allow interop with other systems and components.
  4. Attach listener to bubbling phase, so parameterized handlers run after simple event listeners, to allow interop with other systems and components.

Note: All salient changes are to `patchEvent.js`; other changes are the result of the build process.