### PR TITLE
Simplified event handlers - Option 2.

### DIFF
--- a/test/src/attrs-props.js
+++ b/test/src/attrs-props.js
@@ -15,7 +15,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<input type="text" disabled custom="abc" custom3="" custom4="foo" id="foo" class="bar baz" min="-1" style="font-family: Arial; font-size: 12px;">';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { id: 1, className: 1, createElement: 1, insertBefore: 1, setAttribute: 5, addEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { id: 1, className: 1, createElement: 1, insertBefore: 1, setAttribute: 5 });
 	});
 
 	// TODO: can 'id' or 'name' be allowed to change for recycling since they implicitly double as keys?
@@ -28,7 +28,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<input type="text" custom="xyz" custom2="..." id="foo" style="padding: 10px;">';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 4, setAttribute: 2, removeEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 4, setAttribute: 2 });
 	});
 
 
@@ -223,7 +223,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<div style="color: red;">moo</div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 1, cssText: 1, textContent: 1, insertBefore: 1, addEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 1, cssText: 1, textContent: 1, insertBefore: 1 });
 
 		attrs = null;		// or simply {}?
 
@@ -232,7 +232,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<div>moo</div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 1, removeEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 1 });
 	});
 
 	QUnit.test("Reused static attrs object", function(assert) {

--- a/test/src/events.js
+++ b/test/src/events.js
@@ -77,11 +77,11 @@ QUnit.module("Events", function() {
 		vm = domvm.createView(View).mount(testyDiv);
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, insertBefore: 2 });
 
 		// clicked args
 		doClick(vm.node.body[0].el);
-		assert.equal(counts.args1.length, 1);
+		assert.equal(counts.args1.length, 4);
 		assert.ok(counts.args1[0] instanceof Event);
 
 		reset();
@@ -106,7 +106,7 @@ QUnit.module("Events", function() {
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
 
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { addEventListener: 1, removeEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, {});
 
 /*		// return false -> preventDefault + stopPropagation
 		// todo: spy on Event.prototype.stopPropagation
@@ -125,7 +125,7 @@ QUnit.module("Events", function() {
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
 
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, {});
 
 		reset();
 	});
@@ -139,7 +139,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, insertBefore: 2 });
 
 		// clicked args
 		doClick(vm.node.body[0].el);
@@ -203,7 +203,7 @@ QUnit.module("Events", function() {
 
 		// TODO: test if "handle" is the thing that's bound
 		// TOFIX: when last listener of this type is dropped, remove top-level capturing listener
-	//	evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
+	//	evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { });
 		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { });
 
 		reset();
@@ -246,7 +246,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, insertBefore: 2 });
 
 		reset();
 
@@ -281,7 +281,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, {});
 
 		reset();
 	});
@@ -295,7 +295,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, insertBefore: 2 });
 
 		reset();
 


### PR DESCRIPTION
@leeoniya 

Change event handler invocation to attach a handler at the View level, and remove the differentiation between "normal" onxxx handlers and "parameterized" onxxx handlers.

I am also fixing tests which now break because add/remove event listener is never called. Additional tests might be needed to ensure handlers are actually invoked, and once removed are not invoked.

Specifically:

  1. Set the onxxx property of the view's element if any child of the view declares an onxxx handler. [4]
  2. Treat function and array handler declarations identically. [1] [3]
  3. Invoke VM and global handlers, therefore, for every child handler. [2] [3]
  4. Add dev note if a non-null handler declaration is not a function or array with the first element a function.
  5. Invoke event handlers in bubbling order.
  6. Set vm.currentTarget while handling an event (because Event.currentTarget is read-only). [3]
  7. Set `this` for event handler invocation to the current target, consistent with normal event handler invocation.

Notes:

  1. Changing this would necessitate the use of `addEventListener`, but would be relatively trivial; since we're always adding a specific, constant function it's likely perfectly fine to simply add without tracking whether or not a the handler is already there (it will almost always be a search of a tiny, like one-element array).
  2. This follows from (1).
  3. While I would not be hugely disappointed if I was forced to always declare event handlers as an array to get this consistency, having this inherently is a big win, in my opinion. It has the benefits of (a) total invocation sequence consistency, (b) total `onevent` invocation consistency, and (c) reducing the number of bindings for both types of handler.
  4. I could not find a reasonable, performant way to subsequently remove a view's onxxx handler once no child of the view has any handlers of that type, but processing the vDOM structure could conceivably ascertain this; in practice an unnecessary handler will do no harm and consume an irrelevant amount of CPU, but it would be nice to be able to efficiently remove it. It may be possible to remove the handler unconditionally, and always call `patchEvent` when processing the vDOM.

Performance measurements (1,000,000 elements with handlers):

Measured Time: 6253

![image](https://user-images.githubusercontent.com/8662551/142283990-e95c5cd6-6852-4555-8397-7e7a0a4106da.png)

````
<script>
const ve = domvm.defineElement;

let done = false;

function onclick() {}

function AppView() {
    return () => {
        if(done) { return ve("h1","DONE!"); }

        let chl = [];
        for(let xa = 0; xa < 1000000; xa++) {
            chl.push(ve("span", { onclick: [onclick] }, "["+xa+"]"));
            }
        return ve("div",chl);
        }
    }

console.time("domvm");
let rootVm = domvm.createView(AppView);
rootVm.cfg({
    hooks: {
        didMount: (vm) => {
            console.timeEnd("domvm");
            setTimeout(() => { done = true; vm.redraw() },1000);
            },
        }
    });
rootVm.mount(document.body);
</script>
````
