### PR TITLE
Standardize event handler `this` to be the same as JS events, and pre…

### DIFF
--- a/src/view/addons/html.js
+++ b/src/view/addons/html.js
@@ -46,21 +46,21 @@ function toStr(val) {
 }
 
 const voidTags = {
-    area: true,
-    base: true,
-    br: true,
-    col: true,
-    command: true,
-    embed: true,
-    hr: true,
-    img: true,
-    input: true,
-    keygen: true,
-    link: true,
-    meta: true,
-    param: true,
-    source: true,
-    track: true,
+	area: true,
+	base: true,
+	br: true,
+	col: true,
+	command: true,
+	embed: true,
+	hr: true,
+	img: true,
+	input: true,
+	keygen: true,
+	link: true,
+	meta: true,
+	param: true,
+	source: true,
+	track: true,
 	wbr: true
 };
 

--- a/src/view/patch.js
+++ b/src/view/patch.js
@@ -175,7 +175,7 @@ function patchChildren(vnode, donor) {
 			}
 
 			if (donor2 != null) {
-                foundIdx = donor2.idx;
+				foundIdx = donor2.idx;
 
 				if (nbody.diff.eq(i, donor2)) {
 					// almost same as reParent() in ViewModel

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -4,43 +4,45 @@ import { onevent } from './config';
 import { devNotify } from "./addons/devmode";
 
 function handle(evt) {
-    let elm = evt.currentTarget,
-        dfn = elm._node.attrs["on" + evt.type];
+	let elm = evt.currentTarget,
+		dfn = elm._node.attrs["on" + evt.type];
 
-    if (isArr(dfn)) {
-        let fn = dfn[0], args = dfn.slice(1);
-    	let node = getVnode(evt.target),
-            vm = getVm(node),
-    		out1 = fn.apply(evt.currentTarget, args.concat(evt, node, vm, vm.data)), out2, out3;
+	if (isArr(dfn)) {
+		let fn = dfn[0], args = dfn.slice(1);
+		let node = getVnode(evt.target),
+			vm = getVm(node),
+			out1 = fn.apply(elm, args.concat([evt, node, vm, vm.data])), // use of array is necessary due concat flattening first level
+			out2,
+			out3;
 
-        if (FEAT_ONEVENT) {
-    		out2 = vm.onevent(evt, node, vm, vm.data, args),
-    		out3 =    onevent(evt, node, vm, vm.data, args);
-        }
+		if (FEAT_ONEVENT) {
+			out2 = vm.onevent(evt, node, vm, vm.data, args),
+			out3 =    onevent(evt, node, vm, vm.data, args);
+		}
 
-        if (out1 === false || out2 === false || out3 === false)
-    		evt.preventDefault();
-    }
-    else
-        dfn.call(elm, evt);
+		if (out1 === false || out2 === false || out3 === false)
+			evt.preventDefault();
+	}
+	else
+		dfn.call(elm, evt);
 }
 
 export function patchEvent(node, name, nval, oval) {
-    if (nval == oval)
-        return;
+	if (nval == oval)
+		return;
 
-    if (_DEVMODE) {
-        if (nval != null && !isFunc(nval) && !isArr(nval))
-            devNotify("INVALID_HANDLER", [node, nval]);
+	if (_DEVMODE) {
+		if (nval != null && !isFunc(nval) && !isArr(nval))
+			devNotify("INVALID_HANDLER", [node, nval]);
 
-        if (isFunc(nval) && nval.name == '')
-            devNotify("INLINE_HANDLER", [node, nval]);
-    }
+		if (isFunc(nval) && nval.name == '')
+			devNotify("INLINE_HANDLER", [node, nval]);
+	}
 
-    let el = node.el;
+	let el = node.el;
 
-    if (nval == null)
-        el.removeEventListener(name.slice(2), handle);
-    else if (oval == null)
-        el.addEventListener(name.slice(2), handle);
+	if (nval == null)
+		el.removeEventListener(name.slice(2), handle);
+	else if (oval == null)
+		el.addEventListener(name.slice(2), handle);
 }

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -1,55 +1,51 @@
 import { isArr, isFunc } from '../utils';
-import { getVm } from './utils';
+import { getVm, getVnode } from './utils';
 import { onevent } from './config';
 import { devNotify } from "./addons/devmode";
 
 // invokes parameterized events
-function exec(fn, args, e, node) {
-	let vm = getVm(node),
-		out1 = fn.apply(vm, args.concat(e, node, vm, vm.data)),
-		out2,
-		out3;
+function exec(fn, args, evt) {
+	let node = getVnode(evt.target),
+        vm = getVm(node),
+		out1 = fn.apply(evt.currentTarget, args.concat(evt, node, vm, vm.data)),
+        out2,
+        out3;
 
-	if (FEAT_ONEVENT) {
-		out2 = vm.onevent(e, node, vm, vm.data, args),
-		out3 =    onevent(e, node, vm, vm.data, args);
-	}
+    if (FEAT_ONEVENT) {
+		out2 = vm.onevent(evt, node, vm, vm.data, args),
+		out3 =    onevent(evt, node, vm, vm.data, args);
+    }
 
-	if (out1 === false || out2 === false || out3 === false)
-		e.preventDefault();
+    if (out1 === false || out2 === false || out3 === false)
+		evt.preventDefault();
 }
 
-function handle(e) {
-	let curTarg = e.currentTarget;
-	let node = curTarg._node;
+function handle(evt) {
+    let elm = evt.currentTarget,
+        dfn = elm._node.attrs["on" + evt.type];
 
-	if (node == null)
-		return;
-
-	let dfn = node.attrs["on" + e.type];
-
-	if (isArr(dfn))
-		exec(dfn[0], dfn.slice(1), e, node);
-	else
-		dfn.call(curTarg, e);
+    if (isArr(dfn))
+        exec(dfn[0], dfn.slice(1), evt);
+    else
+        dfn.call(elm, evt);
 }
 
 export function patchEvent(node, name, nval, oval) {
-	if (nval == oval)
-		return;
+    if (nval == oval)
+        return;
 
-	if (_DEVMODE) {
-		if (nval != null && !isFunc(nval) && !isArr(nval))
-			devNotify("INVALID_HANDLER", [node, nval]);
+    if (_DEVMODE) {
+        if (nval != null && !isFunc(nval) && !isArr(nval))
+            devNotify("INVALID_HANDLER", [node, nval]);
 
-		if (isFunc(nval) && nval.name == '')
-			devNotify("INLINE_HANDLER", [node, nval]);
-	}
+        if (isFunc(nval) && nval.name == '')
+            devNotify("INLINE_HANDLER", [node, nval]);
+    }
 
-	let el = node.el;
+    let el = node.el;
 
-	if (nval == null)
-		el[name] = null;
-	else if (oval == null)
-		el[name] = handle;
+    if (nval == null)
+        el[name] = null;
+    else if (oval == null)
+        el[name] = handle;
 }

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -40,7 +40,7 @@ export function patchEvent(node, name, nval, oval) {
     let el = node.el;
 
     if (nval == null)
-        el[name] = null;
+        el.removeEventListener(name.slice(2), handle);
     else if (oval == null)
-        el[name] = handle;
+        el.addEventListener(name.slice(2), handle);
 }

--- a/src/view/patchEvent.js
+++ b/src/view/patchEvent.js
@@ -3,29 +3,24 @@ import { getVm, getVnode } from './utils';
 import { onevent } from './config';
 import { devNotify } from "./addons/devmode";
 
-// invokes parameterized events
-function exec(fn, args, evt) {
-	let node = getVnode(evt.target),
-        vm = getVm(node),
-		out1 = fn.apply(evt.currentTarget, args.concat(evt, node, vm, vm.data)),
-        out2,
-        out3;
-
-    if (FEAT_ONEVENT) {
-		out2 = vm.onevent(evt, node, vm, vm.data, args),
-		out3 =    onevent(evt, node, vm, vm.data, args);
-    }
-
-    if (out1 === false || out2 === false || out3 === false)
-		evt.preventDefault();
-}
-
 function handle(evt) {
     let elm = evt.currentTarget,
         dfn = elm._node.attrs["on" + evt.type];
 
-    if (isArr(dfn))
-        exec(dfn[0], dfn.slice(1), evt);
+    if (isArr(dfn)) {
+        let fn = dfn[0], args = dfn.slice(1);
+    	let node = getVnode(evt.target),
+            vm = getVm(node),
+    		out1 = fn.apply(evt.currentTarget, args.concat(evt, node, vm, vm.data)), out2, out3;
+
+        if (FEAT_ONEVENT) {
+    		out2 = vm.onevent(evt, node, vm, vm.data, args),
+    		out3 =    onevent(evt, node, vm, vm.data, args);
+        }
+
+        if (out1 === false || out2 === false || out3 === false)
+    		evt.preventDefault();
+    }
     else
         dfn.call(elm, evt);
 }

--- a/src/view/utils.js
+++ b/src/view/utils.js
@@ -49,3 +49,10 @@ export function getVm(n) {
 		n = n.parent;
 	return n.vm;
 }
+
+export function getVnode(el) {
+	el = el || emptyObj;
+	while (el._node == null && el.parentNode)
+		el = el.parent;
+	return el._node;
+}

--- a/test/src/attrs-props.js
+++ b/test/src/attrs-props.js
@@ -15,7 +15,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<input type="text" disabled custom="abc" custom3="" custom4="foo" id="foo" class="bar baz" min="-1" style="font-family: Arial; font-size: 12px;">';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { id: 1, className: 1, createElement: 1, insertBefore: 1, setAttribute: 5, onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { id: 1, className: 1, createElement: 1, insertBefore: 1, setAttribute: 5, addEventListener: 1 });
 	});
 
 	// TODO: can 'id' or 'name' be allowed to change for recycling since they implicitly double as keys?
@@ -28,7 +28,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<input type="text" custom="xyz" custom2="..." id="foo" style="padding: 10px;">';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 4, setAttribute: 2, onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 4, setAttribute: 2, removeEventListener: 1 });
 	});
 
 
@@ -223,7 +223,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<div style="color: red;">moo</div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 1, cssText: 1, textContent: 1, insertBefore: 1, onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 1, cssText: 1, textContent: 1, insertBefore: 1, addEventListener: 1 });
 
 		attrs = null;		// or simply {}?
 
@@ -232,7 +232,7 @@ QUnit.module("Attrs/props", function() {
 		var callCounts = instr.end();
 
 		var expcHtml = '<div>moo</div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 1, onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeAttribute: 1, removeEventListener: 1 });
 	});
 
 	QUnit.test("Reused static attrs object", function(assert) {

--- a/test/src/events.js
+++ b/test/src/events.js
@@ -40,13 +40,13 @@ QUnit.module("Events", function() {
 	reset();
 
 	function click1() {
-        counts.this1 = this;
+		counts.this1 = this;
 		counts.args1 = Array.prototype.slice.call(arguments);
 		counts.clicks1++;
 	}
 
 	function click2() {
-        counts.this2 = this;
+		counts.this2 = this;
 		counts.args2 = Array.prototype.slice.call(arguments);
 		counts.clicks2++;
 		return false;

--- a/test/src/events.js
+++ b/test/src/events.js
@@ -40,11 +40,13 @@ QUnit.module("Events", function() {
 	reset();
 
 	function click1() {
+        counts.this1 = this;
 		counts.args1 = Array.prototype.slice.call(arguments);
 		counts.clicks1++;
 	}
 
 	function click2() {
+        counts.this2 = this;
 		counts.args2 = Array.prototype.slice.call(arguments);
 		counts.clicks2++;
 		return false;
@@ -81,6 +83,7 @@ QUnit.module("Events", function() {
 
 		// clicked args
 		doClick(vm.node.body[0].el);
+		assert.ok(counts.this1 instanceof Element);
 		assert.equal(counts.args1.length, 1);
 		assert.ok(counts.args1[0] instanceof Event);
 
@@ -143,6 +146,7 @@ QUnit.module("Events", function() {
 
 		// clicked args
 		doClick(vm.node.body[0].el);
+		assert.ok(counts.this1 instanceof Element);
 		assert.equal(counts.args1.length, 6);
 		assert.equal(counts.args1[0], 1);
 		assert.equal(counts.args1[1], 2);
@@ -179,6 +183,7 @@ QUnit.module("Events", function() {
 
 		// clicked args
 		doClick(vm.node.body[0].el);
+		assert.ok(counts.this2 instanceof Element);
 		assert.equal(counts.args2.length, 6);
 		assert.equal(counts.args2[0], 3);
 		assert.equal(counts.args2[1], 4);
@@ -213,23 +218,24 @@ QUnit.module("Events", function() {
 		vm.redraw();
 
 		doClick(vm.node.body[0].el);
+		assert.ok(counts.this1 instanceof Element);
 		assert.equal(counts.args1.length, 6);
 		assert.equal(counts.args1[0], 5);
 		assert.equal(counts.args1[1], 6);
 		assert.ok(counts.args1[2] instanceof Event);
-		assert.equal(counts.args1[3], vm.node);
+		assert.equal(counts.args1[3], vm.node.body[0]);
 		assert.equal(counts.args1[4], vm);
 		assert.equal(counts.args1[5], vm.data);
 
 		// global & vm-level onevent args
 		assert.ok(counts.globalOnArgs[0] instanceof Event);
-		assert.equal(counts.globalOnArgs[1], vm.node);
+		assert.equal(counts.globalOnArgs[1], vm.node.body[0]);
 		assert.equal(counts.globalOnArgs[2], vm);
 		assert.equal(counts.globalOnArgs[3], vm.data);
 		assert.deepEqual(counts.globalOnArgs[4], [5,6]);
 
 		assert.ok(counts.vmOnArgs[0] instanceof Event);
-		assert.equal(counts.vmOnArgs[1], vm.node);
+		assert.equal(counts.vmOnArgs[1], vm.node.body[0]);
 		assert.equal(counts.vmOnArgs[2], vm);
 		assert.equal(counts.vmOnArgs[3], vm.data);
 		assert.deepEqual(counts.vmOnArgs[4], [5,6]);

--- a/test/src/events.js
+++ b/test/src/events.js
@@ -79,7 +79,7 @@ QUnit.module("Events", function() {
 		vm = domvm.createView(View).mount(testyDiv);
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, onclick: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
 
 		// clicked args
 		doClick(vm.node.body[0].el);
@@ -128,7 +128,7 @@ QUnit.module("Events", function() {
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
 
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
 
 		reset();
 	});
@@ -142,7 +142,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, onclick: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
 
 		// clicked args
 		doClick(vm.node.body[0].el);
@@ -206,10 +206,7 @@ QUnit.module("Events", function() {
 		var callCounts = instr.end();
 		var expcHtml = '<div><input></div>';
 
-		// TODO: test if "handle" is the thing that's bound
-		// TOFIX: when last listener of this type is dropped, remove top-level capturing listener
-	//	evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { onclick: 1 });
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
 
 		reset();
 
@@ -252,7 +249,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, onclick: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
 
 		reset();
 
@@ -287,7 +284,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { onclick: 1 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { removeEventListener: 1 });
 
 		reset();
 	});
@@ -301,7 +298,7 @@ QUnit.module("Events", function() {
 		var expcHtml = '<div><input></div>';
 
 		// TODO: test if "handle" is the thing that's bound
-		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, onclick: 1, insertBefore: 2 });
+		evalOut(assert, vm.node.el, vm.html(), expcHtml, callCounts, { createElement: 2, addEventListener: 1, insertBefore: 2 });
 
 		reset();
 


### PR DESCRIPTION
Standardize event handler `this` to match JS events; prefer original target nearest node over current target node.

Refer to #240 for rationale.